### PR TITLE
Remove the internal reference to style.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ electron app
 
 ```javascript
 import { TitleBar } from 'electron-react-titlebar'
+import 'electron-react-titlebar/assets/style.css'
 
 ReactDOM.render(
     <TitleBar menu={menuTemplate} icon={iconPath} />,

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import { MenuBar } from './menu'
 
 export const TitleBar = ({ icon, menu, disableMinimize, disableMaximize, className }) => (
   <div id="electron-app-title-bar" className={`electron-app-title-bar ${className || ''}`}>
-    <link href={__dirname + "/../assets/style.css"} rel="stylesheet" />
     <div className="resize-handle resize-handle-top" />
     <div className="resize-handle resize-handle-left" />
     <img className="icon" src={icon} />


### PR DESCRIPTION
I've found that style.css wasn't loading correctly when running electron locally (I haven't tested production but presumably I'd have the same problem). I receive the following error in chrome:

`GET file://../assets/style.css net::ERR_FILE_NOT_FOUND`

From what I've seen of other NPM packages ([react-select](https://github.com/JedWatson/react-select) is one example), they often require that the consuming application explicitly load the CSS themselves. For instance, my app would need to do the following:

```
import { TitleBar } from 'electron-react-titlebar'
import 'electron-react-titlebar/assets/style.css'

ReactDOM.render(
    <TitleBar menu={menuTemplate} icon={iconPath} />,
    document.querySelector('title-bar')
)
```

Obviously it'd be preferable to fix the reference so it didn't fail - if you know of a way to do that (or think I'm doing something wrong!) then consider this an bug report :)