### PR TITLE
Pass children through to TitleBar

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ ReactDOM.render(
 
 ### Options
 
+#### children
+
+Elements to be rendered in between the menu and the window controls (optional).
+
 #### disableMinimize
 
 Disable minimize button

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,17 +19,19 @@ var _menu = require('./menu');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-const TitleBar = exports.TitleBar = ({ icon, menu, disableMinimize, disableMaximize, className }) => _react2.default.createElement(
+const TitleBar = exports.TitleBar = ({ children, icon, menu, disableMinimize, disableMaximize, className }) => _react2.default.createElement(
   'div',
   { id: 'electron-app-title-bar', className: `electron-app-title-bar ${className || ''}` },
   _react2.default.createElement('div', { className: 'resize-handle resize-handle-top' }),
   _react2.default.createElement('div', { className: 'resize-handle resize-handle-left' }),
   typeof icon !== 'undefined' && _react2.default.createElement('img', { className: 'icon', src: icon }),
   _react2.default.createElement(_menu.MenuBar, { menu: menu }),
+  children,
   _react2.default.createElement(_windowControls.WindowControls, { disableMinimize: disableMinimize, disableMaximize: disableMaximize })
 );
 
 TitleBar.propTypes = {
+  children: _propTypes2.default.node,
   icon: _propTypes2.default.string,
   disableMinimize: _propTypes2.default.bool,
   disableMaximize: _propTypes2.default.bool,

--- a/src/index.js
+++ b/src/index.js
@@ -4,17 +4,19 @@ import PropTypes from 'prop-types'
 import { WindowControls } from './window-controls'
 import { MenuBar } from './menu'
 
-export const TitleBar = ({ icon, menu, disableMinimize, disableMaximize, className }) => (
+export const TitleBar = ({ children, icon, menu, disableMinimize, disableMaximize, className }) => (
   <div id="electron-app-title-bar" className={`electron-app-title-bar ${className || ''}`}>
     <div className="resize-handle resize-handle-top" />
     <div className="resize-handle resize-handle-left" />
     {typeof icon !== 'undefined' && <img className="icon" src={icon} />}
     <MenuBar menu={menu} />
+    {children}
     <WindowControls disableMinimize={disableMinimize} disableMaximize={disableMaximize} />
   </div>
 )
 
 TitleBar.propTypes = {
+  children: PropTypes.node,
   icon: PropTypes.string,
   disableMinimize: PropTypes.bool,
   disableMaximize: PropTypes.bool,


### PR DESCRIPTION
I'd occasionally like to render a filename or other arbitrary content in the title bar: 

![capture](https://user-images.githubusercontent.com/391950/30405388-e5fb71a6-992e-11e7-9618-f09ed95c07cb.PNG)

This PR allows rendering the children of `<TitleBar>`