### PR TITLE
Remove @types/electron from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "email": "root@kochiyaocean.org"
   },
   "devDependencies": {
-    "@types/electron": "^1.6.10",
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-plugin-add-module-exports": "^0.2.1",


### PR DESCRIPTION
npm WARN deprecated `@types/electron@1.6.10`: This is a stub types definition for electron (https://github.com/electron/electron). electron provides its own type definitions, so you don't need `@types/electron` installed!