### PR TITLE
Remove dependency on 'electron/remote' for the window-controls. Need …

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Path to icon file (optional).
 
 ### currentWindow?: \<BrowserWindow\>
 
-The browserWindow Object that window controls affect to. Default value is `remote.currentWindow()` (optional).
+The browserWindow Object that window controls affect to (optional).
 
 ### menu?: \<MenuTemplate\>
 

--- a/src/window-controls.js
+++ b/src/window-controls.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { remote } from 'electron'
 import PropTypes from 'prop-types'
 
 export class WindowControls extends Component {
@@ -9,34 +8,36 @@ export class WindowControls extends Component {
     currentWindow: PropTypes.object,
   }
   static defaultProps = {
-    currentWindow: remote.getCurrentWindow(),
   }
   state = {
-    isMaximized: this.props.currentWindow.isMaximized(),
+    isMaximized: this.props.currentWindow && this.props.currentWindow.isMaximized(),
   }
   componentDidMount = () => {
-    this.props.currentWindow.addListener('maximize', e => this.setState({ isMaximized: true }))
-    this.props.currentWindow.addListener('unmaximize', e => this.setState({ isMaximized: false }))
+    if (this.props.currentWindow) {
+      this.props.currentWindow.addListener('maximize', e => this.setState({ isMaximized: true }))
+      this.props.currentWindow.addListener('unmaximize', e => this.setState({ isMaximized: false }))
+    }
   }
   render() {
     const { disableMaximize, disableMinimize } = this.props
     const { isMaximized } = this.state
-    return (
+    const { currentWindow } = this.props;
+    return (currentWindow &&
       <div className="window-controls">
         <button aria-label="minimize" tabIndex="-1" className="window-control window-minimize" disabled={disableMinimize}
-          onClick={e => this.props.currentWindow.minimize()}>
+          onClick={e => currentWindow.minimize()}>
           <svg aria-hidden="true" version="1.1" width="10" height="10">
             <path d="M 0,5 10,5 10,6 0,6 Z" />
           </svg>
         </button>
         <button aria-label="maximize" tabIndex="-1" className="window-control window-maximize" disabled={disableMaximize}
-          onClick={e => this.props.currentWindow.isMaximizable() ? this.props.currentWindow.isMaximized() ? this.props.currentWindow.unmaximize() : this.props.currentWindow.maximize() : null}>
+          onClick={e => currentWindow.isMaximizable() ? (currentWindow.isMaximized() ? currentWindow.unmaximize() : currentWindow.maximize()) : null}>
           <svg aria-hidden="true" version="1.1" width="10" height="10">
             <path d={isMaximized? "m 2,1e-5 0,2 -2,0 0,8 8,0 0,-2 2,0 0,-8 z m 1,1 6,0 0,6 -1,0 0,-5 -5,0 z m -2,2 6,0 0,6 -6,0 z" : "M 0,0 0,10 10,10 10,0 Z M 1,1 9,1 9,9 1,9 Z"} />
           </svg>
         </button>
         <button aria-label="close" tabIndex="-1" className="window-control window-close"
-          onClick={e => this.props.currentWindow.close()}>
+          onClick={e => currentWindow.close()}>
           <svg aria-hidden="true" version="1.1" width="10" height="10">
             <path d="M 0,0 0,0.7 4.3,5 0,9.3 0,10 0.7,10 5,5.7 9.3,10 10,10 10,9.3 5.7,5 10,0.7 10,0 9.3,0 5,4.3 0.7,0 Z" />
           </svg>


### PR DESCRIPTION
…to do the same for other code.

There are still other references to `electron.remote` - but, this can be a good starting point